### PR TITLE
Implement [guard x] for closure capture lists

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -222,6 +222,7 @@ public:
   virtual NullablePtr<DeclAttribute> getDeclAttributeIfAny() const {
     return nullptr;
   }
+  virtual NullablePtr<Stmt> getParentStmtIfAny() const;
 
 #pragma mark - debugging and printing
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1669,9 +1669,12 @@ public:
           SourceLoc &throwsLoc,
           SourceLoc &arrowLoc,
           TypeExpr *&explicitResultType,
-          SourceLoc &inLoc);
+          SourceLoc &inLocm,
+          SmallVectorImpl<Identifier> &varsForSynthesizedGuard);
 
   Expr *parseExprAnonClosureArg();
+  GuardStmt *synthesizedGuardStmt(SmallVectorImpl<Identifier> &varsForSynthesizedGuard,
+                                  SourceLoc guardLoc);
   ParserResult<Expr> parseExprList(tok LeftTok, tok RightTok,
                                    syntax::SyntaxKind Kind);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2936,6 +2936,20 @@ ParserResult<Expr> Parser::parseExprClosure() {
   auto guardStmt = synthesizedGuardStmt(varsForSynthesizedGuard, inLoc);
   if (guardStmt) {
     bodyElements.push_back(guardStmt);
+    
+    // If the capture list has `[guard self]` then we can
+    // allow implicit self in the closure body.
+    bool guardsSelf = false;
+    
+    for (auto identifier : varsForSynthesizedGuard) {
+      if (identifier.str() == "self") {
+        guardsSelf = true;
+        break;
+      }
+    }
+    
+    if (guardsSelf)
+      closure->setAllowsImplicitSelfCapture();
   }
   
   Status |= parseBraceItems(bodyElements, BraceItemListKind::Brace);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1711,6 +1711,11 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       if (auto *VD = closureExpr->getCapturedSelfDecl()) {
         // Either this is a weak capture of self...
         if (VD->getType()->is<WeakStorageType>()) {
+          // `[guard self]` captures have runtime semantics of `[weak self]`
+          // but allows implicit `self.` references.
+          if (closureExpr->allowsImplicitSelfCapture())
+            return false;
+          
           Diags.diagnose(VD->getLoc(), diag::note_self_captured_weakly);
         // ...or something completely different.
         } else {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -164,6 +164,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in x += 1 })
     doVoidStuff({ [unowned(unsafe) self] in x += 1 })
     doVoidStuff({ [unowned self = self] in x += 1 })
+    doVoidStuff({ [guard self] in x += 1 })
 
     doStuff({ [self] in x+1 })
     doStuff({ [self = self] in x+1 })
@@ -199,6 +200,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in _ = method() })
     doVoidStuff({ [unowned(unsafe) self] in _ = method() })
     doVoidStuff({ [unowned self = self] in _ = method() })
+    doVoidStuff({ [guard self] in _ = method() })
 
     doStuff { self.method() }
     doStuff { [self] in method() }
@@ -322,6 +324,7 @@ func testCaptureBehavior(_ ptr : SomeClass) {
   let v2 : SomeClass = ptr
 
   doStuff { [weak v1] in v1!.foo() }
+  // doStuff { [guard v1] in v1.foo() } // This should fail, todo: write expected error
   // expected-warning @+2 {{variable 'v1' was written to, but never read}}
   doStuff { [weak v1,                 // expected-note {{previous}}
              weak v1] in v1!.foo() }  // expected-error {{invalid redeclaration of 'v1'}}


### PR DESCRIPTION
This draft change implements a hypothetical `[guard x]` syntax for closure capture lists -- a `guard` capture behaves like a `weak` capture (e.g. the value is not retained), but the closure body only executes if the captured value still exists. Unlike `[weak x]`, `[guard x]` enables implicit `self.` references in the closure body.

For example, these two examples closures behave identically:

```swift
class Foo {
  
    let propertyOnSelf = "propertyOnSelf"
    lazy var child = Foo()
  
    lazy var guardClosure = { [guard self, guard child] in
        print(propertyOnSelf) // Supports implicit self!
        print(child.propertyOnSelf)
    }

    lazy var weakClosure = { [weak self, weak child] in
        guard let self = self, let child = child else { return }
        print(self.propertyOnSelf)
        print(self.child.propertyOnSelf)
    }
  
}
```